### PR TITLE
Remove upper bound on dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.8.4"
 description = "Create GitHub Actions using Python"
 authors = [{ name = "Sadra Yahyapour", email = "lnxpylnxpy@gmail.com" }]
 requires-python = ">=3.9"
-dependencies = ["pydantic ~= 2.9.2", "requests ~= 2.32.3"]
+dependencies = ["pydantic >= 2.9.2", "requests >= 2.32.3"]
 readme = { file = "README.md", content-type = "text/markdown" }
 license = { file = "LICENSE" }
 classifiers = [
@@ -31,7 +31,7 @@ pyaction = "pyaction.cli:cli"
 
 [project.optional-dependencies]
 dev = ["coverage", "pytest-cookies"]
-cli = ["copier ~= 9.2", "click ~= 8.1", "python-dotenv ~= 1.0.1"]
+cli = ["copier >= 9.2", "click >= 8.1", "python-dotenv >= 1.0.1"]
 
 [project.urls]
 Documentation = "https://pyaction.imsadra.me"


### PR DESCRIPTION
It is considered a bad practice to add upper bounds to dependencies for libraries (not to be confused with applications).

Further reading: https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special

If you are worrying about tests that could break, you can use a lock file.